### PR TITLE
Some versions of puppet want a dependency key set

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "summary": "A native Puppet module that manages XML documents using REXML.",
   "license": "MIT",
   "source": "https://github.com/Areson/xml_fragment",
+  "dependencies": [],
   "project_page": "https://github.com/Areson/xml_fragment",
   "issues_url": "https://github.com/Areson/xml_fragment/issues",
   "tags": [


### PR DESCRIPTION
Our Puppet agents were unable to pull down the custom provider and type onto our servers until this setting was set (pluginsyc is enabled).  No Errors or warning are thrown by the agents.

We found the issue by trying to list the installed modules.

`[root@puppetmaster environments]# puppet module list
Error: No dependencies module metadata provided for xml_fragment
Error: Try 'puppet help module list' for usage`
