### PR TITLE
Validate `content['attributes']` is a hash

### DIFF
--- a/lib/puppet/type/xml_fragment.rb
+++ b/lib/puppet/type/xml_fragment.rb
@@ -45,10 +45,11 @@ Puppet::Type.newtype(:xml_fragment) do
     defaultto {}
 
     validate do |value|
-      raise ArgumentError, 'Value must be a hash.' unless value.is_a?(Hash)
-      raise ArgumentError, 'Value must be a string.' if value.key?('value') && !value['value'].is_a?(String)
+      raise ArgumentError, '`content` must be a hash.' unless value.is_a?(Hash)
+      raise ArgumentError, '`content[\'value\']` must be a string if specified' if value.key?('value') && !value['value'].is_a?(String)
 
       if value.key?('attributes')
+        raise ArgumentError, 'attributes must be a hash.' unless value['attributes'].is_a?(Hash)
         has_contents = false
         value['attributes'].each do |key, val|
           has_contents = true
@@ -57,8 +58,6 @@ Puppet::Type.newtype(:xml_fragment) do
           unless val.is_a?(String)
             value['attributes'][key] = val.to_s
           end
-
-          raise ArgumentError, "Attribute #{key} must be a string." unless value['attributes'][key].is_a?(String)
         end
 
         raise ArgumentError, 'You must specify at least one attribute for a tag if you include the attributes hash.' unless has_contents

--- a/spec/unit/puppet/type/xml_fragment_spec.rb
+++ b/spec/unit/puppet/type/xml_fragment_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:xml_fragment) do
+  describe 'when validating property values' do
+    describe 'content' do
+      it 'accepts hashes' do
+        expect { described_class.new(:name => 'example_resource', :content => {}) }.to_not raise_error
+      end
+      it 'rejects strings' do
+        expect { described_class.new(:name => 'example_resource', :content => 'invalid') }.to raise_error(Puppet::Error, %r{`content` must be a hash})
+      end
+      describe 'value key' do
+        it 'accepts strings' do
+          expect { described_class.new(:name => 'example_resource', :content => { 'value' => 'some value' }) }.to_not raise_error
+        end
+        it 'rejects non strings' do
+          expect { described_class.new(:name => 'example_resource', :content => { 'value' => 1 }) }.to raise_error(Puppet::Error, %r{content\['value'\]` must be a string if specified})
+        end
+      end
+      describe 'attributes key' do
+        it 'accepts a non empty hash' do
+          expect { described_class.new(:name => 'example_resource', :content => { 'attributes' => {'foo' => 'bar' }}) }.to_not raise_error
+        end
+        it 'does not support empty hashes' do
+          expect { described_class.new(:name => 'example_resource', :content => { 'attributes' => {} }) }.to raise_error(Puppet::Error, %r{You must specify at least one attribute for a tag if you include the attributes hash})
+        end
+        it 'does not accept strings' do
+          expect { described_class.new(:name => 'example_resource', :content => { 'attributes' => 'invalid' }) }.to raise_error(Puppet::Error, %r{attributes must be a hash})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this commit, the code explodes when trying to iterate eg. a
string.

```
Validate method failed for class content: undefined method `each' for "":String
```

I've also reworded a couple of other ArgumentError messages and removed
a line that was unreachable.