### PR TITLE
Fix `undefined method `key?' for nil:NilClass` in `set_tag`

### DIFF
--- a/lib/puppet/util/xml_file.rb
+++ b/lib/puppet/util/xml_file.rb
@@ -133,11 +133,11 @@ module Puppet::Util
 
         new_element = REXML::Element.new(tag)
 
-        if value.key?('value')
+        if value && value.key?('value')
           new_element.text = value['value']
         end
 
-        if value.key?('attributes')
+        if value && value.key?('attributes')
           new_element.add_attributes(value['attributes'])
         end
 


### PR DESCRIPTION
Fixes
```
undefined method `key?' for nil:NilClass
/opt/puppetlabs/puppet/cache/lib/puppet/util/xml_file.rb:136:in `block in set_tag'
/opt/puppetlabs/puppet/lib/ruby/2.5.0/rexml/xpath.rb:68:in `each'
/opt/puppetlabs/puppet/lib/ruby/2.5.0/rexml/xpath.rb:68:in `each'
/opt/puppetlabs/puppet/cache/lib/puppet/util/xml_file.rb:112:in `set_tag'
/opt/puppetlabs/puppet/cache/lib/puppet/provider/xml_fragment/xml_fragment.rb:154:in `create'
```