### PR TITLE
Support puppet 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
I've been using it with puppet 6 for the last 6 months or so.

Dunno if you want to drop puppet 3/4 support?